### PR TITLE
Feature/add function create schedule

### DIFF
--- a/frontend/src/components/Calendar.vue
+++ b/frontend/src/components/Calendar.vue
@@ -20,11 +20,13 @@
         :day-format="(timestamp) => new Date(timestamp.date).getDate()"
         :month-format="(timestamp) => new Date(timestamp.date).getMonth() + 1 + '/'"
         @click:event="showEvent"
+        @click:day="initEvent"
       ></v-calendar>
     </v-sheet>
 
     <v-dialog :value="event !== null" @click:outside="closeDialog" width="600">
       <EventDetailDialog v-if="event !== null" />
+      <EventFormDialog v-if="event !== null"></EventFormDialog>
     </v-dialog>
   </div>
 </template>
@@ -33,11 +35,13 @@
 import { format } from 'date-fns';
 import { mapGetters, mapActions } from 'vuex';
 import EventDetailDialog from './EventDetailDialog';
+import EventFormDialog from './EventFormDialog';
 
 export default {
   name: 'Calendar',
   components: {
     EventDetailDialog,
+    EventFormDialog,
   },
   data: () => ({
     value: format(new Date(), 'yyyy/MM/dd'),
@@ -53,11 +57,19 @@ export default {
     setToday() {
       this.value = format(new Date(), 'yyyy/MM/dd');
     },
-    showEvent({ event }) {
+    // showEvent({ event }) {
+    showEvent({ nativeEvent, event }) {
       this.setEvent(event);
+      nativeEvent.stopPropagation();
     },
     closeDialog() {
       this.setEvent(null);
+    },
+    initEvent({ date }) {
+      date = date.replace(/-/g, '/');
+      const start = format(new Date(date), 'yyyy/MM/dd 00:00:00');
+      const end = format(new Date(date), 'yyyy/MM/dd 00:00:00');
+      this.setEvent({ name: '', start, end, timed: true });
     },
   },
 };

--- a/frontend/src/components/Calendar.vue
+++ b/frontend/src/components/Calendar.vue
@@ -25,8 +25,8 @@
     </v-sheet>
 
     <v-dialog :value="event !== null" @click:outside="closeDialog" width="600">
-      <EventDetailDialog v-if="event !== null" />
-      <EventFormDialog v-if="event !== null"></EventFormDialog>
+      <EventDetailDialog v-if="event !== null && !isEditMode" />
+      <EventFormDialog v-if="event !== null && isEditMode" />
     </v-dialog>
   </div>
 </template>
@@ -47,13 +47,13 @@ export default {
     value: format(new Date(), 'yyyy/MM/dd'),
   }),
   computed: {
-    ...mapGetters('events', ['events', 'event']),
+    ...mapGetters('events', ['events', 'event', 'isEditMode']),
     title() {
       return format(new Date(this.value), 'yyyy年 M月');
     },
   },
   methods: {
-    ...mapActions('events', ['fetchEvents', 'setEvent']),
+    ...mapActions('events', ['fetchEvents', 'setEvent', 'setEditMode']),
     setToday() {
       this.value = format(new Date(), 'yyyy/MM/dd');
     },
@@ -64,12 +64,14 @@ export default {
     },
     closeDialog() {
       this.setEvent(null);
+      this.setEditMode(false);
     },
     initEvent({ date }) {
       date = date.replace(/-/g, '/');
       const start = format(new Date(date), 'yyyy/MM/dd 00:00:00');
       const end = format(new Date(date), 'yyyy/MM/dd 00:00:00');
       this.setEvent({ name: '', start, end, timed: true });
+      this.setEditMode(true);
     },
   },
 };

--- a/frontend/src/components/DateForm.vue
+++ b/frontend/src/components/DateForm.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <v-date-picker
+      :value="value"
+      @input="$emit('input', $event)"
+      no-title
+      locale="ja-ja"
+      :day-format="(value) => new Date(value).getDate()"
+    ></v-date-picker>
+    <p>{{ value }}</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DateForm',
+  props: ['value'],
+};
+</script>

--- a/frontend/src/components/DateForm.vue
+++ b/frontend/src/components/DateForm.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <v-menu offset-y>
+    <template v-slot:activator="{ on }">
+      <v-btn text v-on="on">{{ value || '日付を選択' }}</v-btn>
+    </template>
     <v-date-picker
       :value="value"
       @input="$emit('input', $event)"
@@ -7,8 +10,7 @@
       locale="ja-ja"
       :day-format="(value) => new Date(value).getDate()"
     ></v-date-picker>
-    <p>{{ value }}</p>
-  </div>
+  </v-menu>
 </template>
 
 <script>

--- a/frontend/src/components/DateForm.vue
+++ b/frontend/src/components/DateForm.vue
@@ -4,8 +4,8 @@
       <v-btn text v-on="on">{{ value || '日付を選択' }}</v-btn>
     </template>
     <v-date-picker
-      :value="value"
-      @input="$emit('input', $event)"
+      :value="value.replace(/\//g, '-')"
+      @input="$emit('input', $event.replace(/-/g, '/'))"
       no-title
       locale="ja-ja"
       :day-format="(value) => new Date(value).getDate()"

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-card class="pb-12">
+    <v-card-actions class="d-flex justify-enc pa-2">
+      <v-btn icon @click="closeDialog">
+        <v-icon size="20px">mdi-close</v-icon>
+      </v-btn>
+    </v-card-actions>
+    <v-card-text>
+      <DialogSection icon="mdi-square" :color="event.color || 'blue'">
+        <v-text-field v-model="name" label="タイトル"></v-text-field>
+      </DialogSection>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex';
+import DialogSection from './DialogSection';
+
+export default {
+  name: 'EventFormDialog',
+  components: {
+    DialogSection,
+  },
+  data: () => ({
+    name: '',
+  }),
+  computed: {
+    ...mapGetters('events', ['event']),
+  },
+  methods: {
+    ...mapActions('events', ['setEvent']),
+    closeDialog() {
+      this.setEvent(null);
+    },
+  },
+};
+</script>

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -10,6 +10,9 @@
         <v-text-field v-model="name" label="タイトル"></v-text-field>
       </DialogSection>
     </v-card-text>
+    <v-card-actions class="d-flex justify-end">
+      <v-btn @click="submit">保存</v-btn>
+    </v-card-actions>
   </v-card>
 </template>
 
@@ -29,10 +32,19 @@ export default {
     ...mapGetters('events', ['event']),
   },
   methods: {
-    ...mapActions('events', ['setEvent', 'setEditMode']),
+    ...mapActions('events', ['setEvent', 'setEditMode', 'createEvent']),
     closeDialog() {
       this.setEditMode(false);
       this.setEvent(null);
+    },
+    submit() {
+      const params = {
+        name: this.name,
+        start: this.event.start,
+        end: this.event.end,
+      };
+      this.createEvent(params);
+      this.closeDialog();
     },
   },
 };

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -10,13 +10,7 @@
         <v-text-field v-model="name" label="タイトル"></v-text-field>
       </DialogSection>
       <DialogSection icon="mdi-clock-outline">
-        <v-date-picker
-          v-model="startDate"
-          no-title
-          locale="ja-ja"
-          :day-format="(startDate) => new Date(startDate).getDate()"
-        ></v-date-picker>
-        <p>{{ startDate }}</p>
+        <DateForm v-model="startDate" />
       </DialogSection>
     </v-card-text>
     <v-card-actions class="d-flex justify-end">
@@ -28,11 +22,13 @@
 <script>
 import { mapGetters, mapActions } from 'vuex';
 import DialogSection from './DialogSection';
+import DateForm from './DateForm';
 
 export default {
   name: 'EventFormDialog',
   components: {
     DialogSection,
+    DateForm,
   },
   data: () => ({
     name: '',

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -11,6 +11,7 @@
       </DialogSection>
       <DialogSection icon="mdi-clock-outline">
         <DateForm v-model="startDate" />
+        <DateForm v-model="endDate" />
       </DialogSection>
     </v-card-text>
     <v-card-actions class="d-flex justify-end">
@@ -34,12 +35,14 @@ export default {
   data: () => ({
     name: '',
     startDate: null,
+    endDate: null,
   }),
   computed: {
     ...mapGetters('events', ['event']),
   },
   created() {
     this.startDate = format(this.event.start, 'yyyy/MM/dd');
+    this.endDate = format(this.event.end, 'yyyy/MM/dd');
   },
   methods: {
     ...mapActions('events', ['setEvent', 'setEditMode', 'createEvent']),
@@ -51,7 +54,7 @@ export default {
       const params = {
         name: this.name,
         start: this.startDate,
-        end: this.event.end,
+        end: this.endDate,
       };
       this.createEvent(params);
       this.closeDialog();

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -29,8 +29,9 @@ export default {
     ...mapGetters('events', ['event']),
   },
   methods: {
-    ...mapActions('events', ['setEvent']),
+    ...mapActions('events', ['setEvent', 'setEditMode']),
     closeDialog() {
+      this.setEditMode(false);
       this.setEvent(null);
     },
   },

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -9,6 +9,15 @@
       <DialogSection icon="mdi-square" :color="event.color || 'blue'">
         <v-text-field v-model="name" label="タイトル"></v-text-field>
       </DialogSection>
+      <DialogSection icon="mdi-clock-outline">
+        <v-date-picker
+          v-model="startDate"
+          no-title
+          locale="ja-ja"
+          :day-format="(startDate) => new Date(startDate).getDate()"
+        ></v-date-picker>
+        <p>{{ startDate }}</p>
+      </DialogSection>
     </v-card-text>
     <v-card-actions class="d-flex justify-end">
       <v-btn @click="submit">保存</v-btn>
@@ -27,6 +36,7 @@ export default {
   },
   data: () => ({
     name: '',
+    startDate: null,
   }),
   computed: {
     ...mapGetters('events', ['event']),
@@ -40,7 +50,7 @@ export default {
     submit() {
       const params = {
         name: this.name,
-        start: this.event.start,
+        start: this.startDate,
         end: this.event.end,
       };
       this.createEvent(params);

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -23,6 +23,7 @@
 import { mapGetters, mapActions } from 'vuex';
 import DialogSection from './DialogSection';
 import DateForm from './DateForm';
+import { format } from 'date-fns';
 
 export default {
   name: 'EventFormDialog',
@@ -36,6 +37,9 @@ export default {
   }),
   computed: {
     ...mapGetters('events', ['event']),
+  },
+  created() {
+    this.startDate = format(this.event.start, 'yyyy/MM/dd');
   },
   methods: {
     ...mapActions('events', ['setEvent', 'setEditMode', 'createEvent']),

--- a/frontend/src/store/modules/events.js
+++ b/frontend/src/store/modules/events.js
@@ -5,6 +5,7 @@ const apiUrl = 'http://localhost:3000';
 const state = {
   events: [],
   event: null,
+  isEditMode: false,
 };
 
 const getters = {
@@ -24,11 +25,13 @@ const getters = {
           end: new Date(state.event.end),
         }
       : null,
+  isEditMode: (state) => state.isEditMode,
 };
 
 const mutations = {
   setEvents: (state, events) => (state.events = events),
   setEvent: (state, event) => (state.event = event),
+  setEditMode: (state, bool) => (state.isEditMode = bool),
 };
 
 const actions = {
@@ -38,6 +41,9 @@ const actions = {
   },
   setEvent({ commit }, event) {
     commit('setEvent', event);
+  },
+  setEditMode({ commit }, bool) {
+    commit('setEditMode', bool);
   },
 };
 

--- a/frontend/src/store/modules/events.js
+++ b/frontend/src/store/modules/events.js
@@ -20,7 +20,7 @@ const getters = {
     state.event
       ? {
           ...state.event,
-          state: new Date(state.event.start),
+          start: new Date(state.event.start),
           end: new Date(state.event.end),
         }
       : null,

--- a/frontend/src/store/modules/events.js
+++ b/frontend/src/store/modules/events.js
@@ -29,12 +29,17 @@ const getters = {
 };
 
 const mutations = {
-  setEvents: (state, events) => (state.events = events),
-  setEvent: (state, event) => (state.event = event),
+  appendEvent: (state, event) => (state.events = [...state.events, event]),
   setEditMode: (state, bool) => (state.isEditMode = bool),
+  setEvent: (state, event) => (state.event = event),
+  setEvents: (state, events) => (state.events = events),
 };
 
 const actions = {
+  async createEvent({ commit }, event) {
+    const response = await axios.post(`${apiUrl}/events`, event);
+    commit('appendEvent', response.data);
+  },
   async fetchEvents({ commit }) {
     const response = await axios.get(`${apiUrl}/events`);
     commit('setEvents', response.data);


### PR DESCRIPTION
## やっていること
- 登録フォームからデータをDBに登録する
- 登録フォームのパーツを変更する

[commit一覧](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")

<!--
リンク
[日付選択フォームを追加する|【Rails × Vue.js】 Googleカレンダー風カレンダーアプリを作ってみよう|Techpit](https://www.techpit.jp/courses/173/curriculums/176/sections/1186/parts/4653)

未学習の項目
クリックした日付をデフォルトの値にする
終了日の日付選択フォームの追加

-->
## 登録フォームからデータをDBに登録する

o 登録フォームの表示
[toshi-ue add(frontend): 登録フォームを表示させる](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/f78a88448c01f353efbf2367e7e1a5ad04a3547c "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")
- stopPropagation() の使い方
- 登録フォームの初期値の設定

o ダイアログが複数存在する時の制御方法
[update(frontend): 2つのダイアログの表示を制御する](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/432bcb26c0a300a65e0b490992b0af49eda02ca4 "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")

o railsのeventscontrollerのcreateアクション呼び出す、frontendで表示させるためのvuexのコードの設定(ブラウザ上からはボタンが存在しないため登録はできない)
[add(frontend): 予定作成アクションを作成](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/fc5b8d050f5841628cf3fba516a728004f2e2448 "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")

o 登録するためのボタン、railsのparamsに値を設定する、DBに保存する
[add(frontend): 予定を登録する ](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/a5112894e07414ef17dfe40a9faea629aaf0eaa7 "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")

## 登録フォームのパーツを変更する



|当日|翌日|3日後|7日後|内容・項目・リンク|
|:----:|:----:|:----:|:----:|:----|
|09_10| (09_11) | (09_13) | (09_17) |日付フォームを追加(VuetifyのDatePickerを使用)<br>[add(frontend): DatePickerの表示 ](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/536da646ec185bcb23a21201e063e4e88db42ba0 "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")|
|09_10| (09_11) | (09_13) | (09_17) |コンポーネント分離した際のデータの受け渡し<br>[update(frontend): date-pickerの表示をDateFormコンポーネントに分割](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/1e80038c4a5cd61f43eb39e7b12e7d31b4aa84bb "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")|
|09_10| (09_11) | (09_13) | (09_17) |日付フォームの表示方法を変更<br>[update(frontend): DatePickerの表示方法を変更](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/0f868a5041e3428ba2baf85a87abfe9e42394aac "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")|


<!--
テンプレート

|| <br>() | <br> | <br> |<br>|

-->