### PR TITLE
vuetifyの`v-color-picker`を使用する

### DIFF
--- a/frontend/src/components/ColorForm.vue
+++ b/frontend/src/components/ColorForm.vue
@@ -4,7 +4,7 @@
       <template v-slot:activator="{ on }">
         <v-btn text v-on="on">
           <v-icon :color="value" size="20px">mdi-circle</v-icon>
-          <v-icon color="rgba(0, 0,0,6)" size="24px">mdi-menu-down</v-icon>
+          <v-icon color="rgba(0, 0, 0, 0.6)" size="24px">mdi-menu-down</v-icon>
         </v-btn>
       </template>
       <v-color-picker hide-canvas hide-inputs show-swatches :value="value" @input="$emit('input', $event)"> </v-color-picker>

--- a/frontend/src/components/ColorForm.vue
+++ b/frontend/src/components/ColorForm.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="d-flex align-center">
+    <v-menu offset-y>
+      <template v-slot:activator="{ on }">
+        <v-btn text v-on="on">
+          <v-icon :color="value" size="20px">mdi-circle</v-icon>
+          <v-icon color="rgba(0, 0,0,6)" size="24px">mdi-menu-down</v-icon>
+        </v-btn>
+      </template>
+      <v-color-picker hide-canvas hide-inputs show-swatches :value="value" @input="$emit('input', $event)"> </v-color-picker>
+    </v-menu>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ColorForm',
+  props: ['value'],
+};
+</script>

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -1,12 +1,12 @@
 <template>
   <v-card class="pb-12">
-    <v-card-actions class="d-flex justify-enc pa-2">
+    <v-card-actions class="d-flex justify-end pa-2">
       <v-btn icon @click="closeDialog">
         <v-icon size="20px">mdi-close</v-icon>
       </v-btn>
     </v-card-actions>
     <v-card-text>
-      <DialogSection icon="mdi-square" :color="event.color">
+      <DialogSection icon="mdi-square" :color="color">
         <v-text-field v-model="name" label="タイトル"></v-text-field>
       </DialogSection>
       <DialogSection icon="mdi-clock-outline">
@@ -18,6 +18,9 @@
       <DialogSection icon="mdi-card-text-outline">
         <TextForm v-model="description" />
       </DialogSection>
+      <DialogSection icon="mdi-palette">
+        <ColorForm v-model="color" />
+      </DialogSection>
     </v-card-text>
     <v-card-actions class="d-flex justify-end">
       <v-btn @click="submit">保存</v-btn>
@@ -27,6 +30,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
+import ColorForm from './ColorForm';
 import DialogSection from './DialogSection';
 import DateForm from './DateForm';
 import TimeForm from './TimeForm';
@@ -35,16 +39,18 @@ import TextForm from './TextForm';
 export default {
   name: 'EventFormDialog',
   components: {
+    ColorForm,
     DialogSection,
     DateForm,
     TimeForm,
     TextForm,
   },
   data: () => ({
-    name: '',
+    color: '',
     description: this.description,
     endDate: null,
     endTime: null,
+    name: '',
     startDate: null,
     startTime: null,
   }),
@@ -52,10 +58,11 @@ export default {
     ...mapGetters('events', ['event']),
   },
   created() {
+    this.color = this.event.color;
     this.startDate = this.event.startDate;
     this.startTime = this.event.startTime;
     this.endDate = this.event.endDate;
-    this.endtTime = this.event.endTime;
+    this.endTime = this.event.endTime;
   },
   methods: {
     ...mapActions('events', ['setEvent', 'setEditMode', 'createEvent']),
@@ -65,6 +72,7 @@ export default {
     },
     submit() {
       const params = {
+        color: this.color,
         description: this.description,
         end: `${this.endDate} ${this.endTime || ''}`,
         name: this.name,

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -47,7 +47,7 @@ export default {
   },
   data: () => ({
     color: '',
-    description: this.description,
+    description: '',
     endDate: null,
     endTime: null,
     name: '',


### PR DESCRIPTION
<!--
該当リンク
[日付選択フォームを追加する|【Rails × Vue.js】 Googleカレンダー風カレンダーアプリを作ってみよう|Techpit](https://www.techpit.jp/courses/173/curriculums/176/sections/1186/parts/4653)
-->

## 学習すること

- vuetifyの`v-color-picker`の使い方

[commit 一覧](https://github.com/toshi-ue/vue_rails_calendar/pull/10/commits "vuetifyの`v-color-picker`を使用する by toshi-ue · Pull Request #10 · toshi-ue/vue_rails_calendar")
## 学習履歴

<!--
|| <br> | <br> | <br> |<br>|
-->

| 当日 | 翌日 | 3 日後 | 7 日後 | 内容・項目・リンク |
| :--: | :--: | :----: | :----: | :----------------- |
|09_16| <br>09_17 |  <br>09_19  |  <br>09_25  ||

<!--
テンプレート

例1
|| <br>日付 | <br>日付 | <br>日付 |コミットメッセージ<br>該当コミットのリンク|

例2
|09_10| <br>09_11 | <br>09_13 | <br>09_17 |コンポーネント分離した際のデータの受け渡し<br>[update(frontend): date-pickerの表示をDateFormコンポーネントに分割](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/1e80038c4a5cd61f43eb39e7b12e7d31b4aa84bb "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")|
-->
