### PR TITLE
checkboxの値による表示の制御

### DIFF
--- a/frontend/src/components/CheckBox.vue
+++ b/frontend/src/components/CheckBox.vue
@@ -1,0 +1,10 @@
+<template>
+  <v-checkbox :value="value" @change="$emit('input', $event)" :label="label"> </v-checkbox>
+</template>
+
+<script>
+export default {
+  name: 'CheckBox',
+  props: ['value', 'label'],
+};
+</script>

--- a/frontend/src/components/EventDetailDialog.vue
+++ b/frontend/src/components/EventDetailDialog.vue
@@ -12,7 +12,7 @@
     </v-card-title>
     <v-card-text>
       <DialogSection icon="mdi-clock-time-three-outline">
-        {{ event.start.toLocaleString() }} ~ {{ event.end.toLocaleString() }}
+        {{ event.startDate }} {{ event.timed ? event.startTime : '' }} ~ {{ event.endDate }} {{ event.timed ? event.endTime : '' }}
       </DialogSection>
     </v-card-text>
     <v-card-text>

--- a/frontend/src/components/EventFormDialog.vue
+++ b/frontend/src/components/EventFormDialog.vue
@@ -11,9 +11,14 @@
       </DialogSection>
       <DialogSection icon="mdi-clock-outline">
         <DateForm v-model="startDate" />
-        <TimeForm v-model="startTime" />
+        <div v-show="!allDay">
+          <TimeForm v-model="startTime" />
+        </div>
         <DateForm v-model="endDate" />
-        <TimeForm v-model="endTime" />
+        <div v-show="!allDay">
+          <TimeForm v-model="endTime" />
+        </div>
+        <CheckBox v-model="allDay" label="終日" />
       </DialogSection>
       <DialogSection icon="mdi-card-text-outline">
         <TextForm v-model="description" />
@@ -30,6 +35,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
+import CheckBox from './CheckBox';
 import ColorForm from './ColorForm';
 import DialogSection from './DialogSection';
 import DateForm from './DateForm';
@@ -39,6 +45,7 @@ import TextForm from './TextForm';
 export default {
   name: 'EventFormDialog',
   components: {
+    CheckBox,
     ColorForm,
     DialogSection,
     DateForm,
@@ -46,6 +53,7 @@ export default {
     TextForm,
   },
   data: () => ({
+    allDay: false,
     color: '',
     description: '',
     endDate: null,
@@ -58,6 +66,7 @@ export default {
     ...mapGetters('events', ['event']),
   },
   created() {
+    this.allDay = this.event.allDay;
     this.color = this.event.color;
     this.startDate = this.event.startDate;
     this.startTime = this.event.startTime;
@@ -77,6 +86,7 @@ export default {
         end: `${this.endDate} ${this.endTime || ''}`,
         name: this.name,
         start: `${this.startDate} ${this.startTime || ''}`,
+        timed: !this.allDay,
       };
       this.createEvent(params);
       this.closeDialog();


### PR DESCRIPTION
<!--
該当リンク
[日付選択フォームを追加する|【Rails × Vue.js】 Googleカレンダー風カレンダーアプリを作ってみよう|Techpit](https://www.techpit.jp/courses/173/curriculums/176/sections/1186/parts/4653)
-->

## 学習すること

- Vuetifyでのcheckbox(v-checkbox)の使い方
- 値による他パーツの表示の制御

[commit 一覧](https://github.com/toshi-ue/vue_rails_calendar/pull/11/commits)

## 学習履歴

<!--
|| <br> | <br> | <br> |<br>|
-->

| 当日 | 翌日 | 3 日後 | 7 日後 | 内容・項目・リンク |
| :--: | :--: | :----: | :----: | :----------------- |
|09_17| <br> |  <br>  |  <br>  | <br>               |

<!--
テンプレート

例1
|| <br>日付 | <br>日付 | <br>日付 |コミットメッセージ<br>該当コミットのリンク|

例2
|09_10| <br>09_11 | <br>09_13 | <br>09_17 |コンポーネント分離した際のデータの受け渡し<br>[update(frontend): date-pickerの表示をDateFormコンポーネントに分割](https://github.com/toshi-ue/vue_rails_calendar/pull/7/commits/1e80038c4a5cd61f43eb39e7b12e7d31b4aa84bb "Feature/add function create schedule by toshi-ue · Pull Request #7 · toshi-ue/vue_rails_calendar")|
-->
